### PR TITLE
Add skeleton Main and shared ViewManager for screen navigation

### DIFF
--- a/src/main/java/app/Main.java
+++ b/src/main/java/app/Main.java
@@ -1,7 +1,80 @@
 package app;
+import javax.swing.*;
+
+import app.factory.DeckManageUseCaseFactory;
+import app.factory.DeckManageUseCaseFactory.DeckMenuBundle;
+
+
+import data_access.DeckDataAccess;
+import data_access.FlashcardDataAccessObject;
+
+
+import usecase.FlashcardDataAccessInterface;
+import usecase.deck.DeckDataAccessInterface;
+
+import view.LoginView;
+import view.ViewManager;
+import view.deck.DeckDetailView;
+import view.deck.DeckMenuView;
+
 
 public class Main {
+
     public static void main(String[] args) {
-        System.out.println("Welcome to our project!");
+
+        // 1) create the main page and ViewManager
+        JFrame frame = new JFrame("VocabVault");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        ViewManager viewManager = new ViewManager(frame);
+
+        // 2) create Data Access instance
+        //TODO: other DAOs & can be replaced by DB implementation later
+        DeckDataAccess deckDAO = new DeckDataAccess();
+        FlashcardDataAccessObject cardDAO = new FlashcardDataAccessObject();
+
+        // assume currently only one user，id = 1
+        int currentUserId = 1;
+
+        // 3) Construct usecase components
+        // TODO: other usecase components
+        // deck uc5 & 10 & 11
+        // 用 DeckManageUseCaseFactory
+        DeckMenuBundle deckBundle =
+                DeckManageUseCaseFactory.build(deckDAO, cardDAO, currentUserId);
+
+        // 4) construct Views
+        // TODO: other views
+        // LoginView
+        LoginView loginView = new LoginView(viewManager);// TODO: implement appropriate constructor here just a placeholder
+        // DeckMenuView
+        DeckMenuView deckMenuView = new DeckMenuView(
+                deckBundle.vm,
+                deckBundle.createController,
+                deckBundle.listController,
+                deckBundle.openController,
+                viewManager
+        );
+
+        // DeckDetailView
+        DeckDetailView deckDetailView = new DeckDetailView(
+                deckBundle.detailVM,
+                deckBundle.openController,
+                viewManager
+        ); // TODO: Jane pls check and change if the DeckDetailView constructor is changed
+
+        // 5) register view to ViewManager
+        // TODO: register other views
+        // notice that the name should be the same as the one used in viewManager.show(name)
+        viewManager.add("Login", loginView);
+        viewManager.add("DeckMenu", deckMenuView);
+        viewManager.add("DeckDetail", deckDetailView);
+
+        // 6) set initial page, I think it's LoginView?
+        SwingUtilities.invokeLater(new Runnable() {
+            @Override
+            public void run() {
+                viewManager.show("Login");
+            }
+        });
     }
 }

--- a/src/main/java/data_access/DeckDataAccessObject.java
+++ b/src/main/java/data_access/DeckDataAccessObject.java
@@ -1,4 +1,0 @@
-package data_access;
-
-public class DeckDataAccessObject {
-}

--- a/src/main/java/view/ViewManager.java
+++ b/src/main/java/view/ViewManager.java
@@ -1,4 +1,46 @@
 package view;
+import javax.swing.*;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ViewManager {
+    private final JFrame frame;
+    // A mapping from view names to their corresponding JPanel instances
+    private final Map<String, JPanel> views;
+    private String current;
+
+    public ViewManager(JFrame frame) {
+        this.frame = frame;
+        this.views = new HashMap<>();
+        // Set default JFrame properties
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setSize(900, 600);
+        frame.setVisible(true);
+    }
+
+    // Add a new view to the manager
+    public void add(String name, JPanel panel) {
+        views.put(name, panel);
+    }
+
+    // Show the view corresponding to the given name
+    public void show(String name) {
+        JPanel panel = views.get(name);
+        // Throw an exception if the view does not exist
+        if (panel == null) {
+            throw new IllegalArgumentException("No view: " + name);
+        }
+        // Set the content pane of the JFrame to the selected view
+        frame.setContentPane(panel);
+        // Refresh the JFrame to display the new view
+        frame.revalidate();
+        frame.repaint();
+        // Update the current view name
+        current = name;
+    }
+
+    public String current() {
+        return current;
+    }
 }
+

--- a/src/test/java/usecase/OpenDeckInteractorTest.java
+++ b/src/test/java/usecase/OpenDeckInteractorTest.java
@@ -1,0 +1,4 @@
+package usecase;
+
+public class OpenDeckInteractorTest {
+}


### PR DESCRIPTION
- Added a skeleton Main class to bootstrap the app with a single JFrame.
(plz modify it with each usecase)
- Introduced a ViewManager to register views and switch screens by name.
- Wired up initial views: DeckMenuView and DeckDetailView using DeckManageUseCaseFactory.

# When you create the view of ur uc:
  - Register it in Main with a string key, e.g. "Login", "DeckMenu".
  - Use the same key with viewManager.show("...") when navigating.